### PR TITLE
Show segfault with write function

### DIFF
--- a/blog-example.php
+++ b/blog-example.php
@@ -82,7 +82,7 @@ function get_request($url)
     CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2
   );
   curl_setopt($ch,
-    CURLOPT_RETURNTRANSFER, 1
+    CURLOPT_RETURNTRANSFER, 0
   );
 
   curl_setopt($ch, CURLOPT_HEADER, false);

--- a/blog-example.php
+++ b/blog-example.php
@@ -32,7 +32,7 @@ class H2PushCache {
       $found = curl_getinfo($handle)['url'];
     }
 
-    static::$cache[$found] = curl_multi_getcontent($handle);
+    static::$cache[$found] = 'noop';//curl_multi_getcontent($handle);
   }
 
   static function exists($url)
@@ -85,6 +85,12 @@ function get_request($url)
     CURLOPT_RETURNTRANSFER, 1
   );
 
+  curl_setopt($ch, CURLOPT_HEADER, false);
+
+  curl_setopt($ch, CURLOPT_WRITEFUNCTION, function ($ch, $data)  {
+      echo 'Write';
+  });
+
   curl_multi_add_handle($mh, $ch);
 
   $active = null;
@@ -112,10 +118,11 @@ function get_request($url)
   return H2PushCache::get($url);
 }
 
-$url = 'https://example/post/1';
+$url = 'https://http2.golang.org/serverpush';
 $response = get_request($url);
-$post = json_decode($response);
-$response = get_request($post->comments);
-$comments = json_decode($reponse);
-$response = get_request($post->author);
-$author = json_decode($response);
+$x = 'noop';
+//$post = json_decode($response);
+//$response = get_request($post->comments);
+//$comments = json_decode($reponse);
+//$response = get_request($post->author);
+//$author = json_decode($response);


### PR DESCRIPTION
```
▶  php blog-example.php
Write[1]    44542 segmentation fault  php blog-example.php
```

```
▶ php -v
PHP 7.2.7 (cli) (built: Jun 22 2018 06:27:50) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
    with Zend OPcache v7.2.7, Copyright (c) 1999-2018, by Zend Technologies
    with Xdebug v2.6.0, Copyright (c) 2002-2018, by Derick Rethans
    with blackfire v1.20.0~mac-x64-non_zts72, https://blackfire.io, by Blackfire
```